### PR TITLE
Fix TempJob leaks by replacing it with WorldUpdateAllocator

### DIFF
--- a/Scripts/SegmentUpdateSystem.cs
+++ b/Scripts/SegmentUpdateSystem.cs
@@ -80,7 +80,7 @@ namespace Segments
         public void OnUpdate ( ref SystemState state )
         {
             int numEntities = _query.CalculateEntityCount();
-            NativeArray<AABB> bounds = new ( numEntities , Allocator.TempJob );
+            NativeArray<AABB> bounds = CollectionHelper.CreateNativeArray<AABB>(numEntities, state.WorldUpdateAllocator);
             _midUpdateData.Clear();
             int i = 0;
 


### PR DESCRIPTION
Just by running the Samples/Basics it emits multiple warning on TempJob leaks:

> JobTempAlloc has allocations that are more than the maximum lifespan of 4 frames old - this is not allowed and likely a leak

In the case of SegmentUpdateSystem, the fix is easy:
- replace Allocator.TempJob with state.WorldUpdateAllocator
- use CollectionHelper to create the array because we're using a custom allocator here